### PR TITLE
Fix crash in heartbeat due to closed websocket

### DIFF
--- a/client.go
+++ b/client.go
@@ -349,15 +349,15 @@ func (c *Client) SubscribePresence(channelName string, opts ...SubscribeOption) 
 // be received from that channe. Note that a nil error does not mean that the
 // unsubscription was successful, just that the request was sent.
 func (c *Client) Unsubscribe(channelName string) error {
-	c.mutex.Lock()
-	defer c.mutex.Unlock()
-
+	c.mutex.RLock()
 	ch, ok := c.subscribedChannels[channelName]
+	c.mutex.RUnlock()
 	if !ok {
 		return nil
 	}
-
+	c.mutex.Lock()
 	delete(c.subscribedChannels, channelName)
+	c.mutex.Unlock()
 	return ch.Unsubscribe()
 }
 

--- a/client.go
+++ b/client.go
@@ -422,6 +422,14 @@ func (c *Client) Disconnect() error {
 	defer c.mutex.Unlock()
 
 	c.connected = false
+	if !c.activityTimer.Stop() {
+		{
+			select {
+			case <-c.activityTimer.C:
+			default:
+			}
+		}
+	}
 	close(c.stopHeartbeat)
 	c.notifyMutex.Lock()
 	defer c.notifyMutex.Unlock()

--- a/client.go
+++ b/client.go
@@ -396,6 +396,9 @@ func (c *Client) Unbind(event string, chans ...chan Event) {
 
 // SendEvent sends an event on the Pusher connection.
 func (c *Client) SendEvent(event string, data interface{}, channelName string) error {
+	if !c.isConnected() {
+		return fmt.Errorf("error in pusher SendEvent, client not connected")
+	}
 	dataJSON, err := json.Marshal(data)
 	if err != nil {
 		return err


### PR DESCRIPTION
A couple of changes to protect heartbeat from causing a crash due to a nil websocket connection. Please see commit descriptions for more detail.
